### PR TITLE
Bg/move int to machine code 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,21 +59,21 @@ Each instruction is 32 bits (4 bytes) long, with the following format:
 
 | Opcode | Instruction | Description |
 |--------|-------------|-------------|
-| 0000 | MOV | Move value between registers or load an immediate value |
-| 0001 | ADD | Add values of two registers |
-| 0010 | SUB | Subtract values of two registers |
-| 0011 | MUL | Multiply values of two registers |
-| 0100 | DIV | Divide values of two registers |
-| 0101 | LOAD | Load a value from memory to register |
-| 0110 | STORE | Store register value to memory |
-| 0111 | JMP | Unconditional jump to address |
-| 1000 | JEQ | Jump if equal |
-| 1001 | JNE | Jump if not equal |
-| 1010 | CALL | Call subroutine at address |
-| 1011 | RET | Return from subroutine |
-| 1100 | PUSH | Push register value to stack |
-| 1101 | POP | Pop top of stack into register |
-| 1110 | INT | Trigger interrupt for I/O |
+| 0000 | INT | Trigger interrupt for I/O |
+| 0001 | MOV | Move value between registers or load an immediate value |
+| 0010 | ADD | Add values of two registers |
+| 0011 | SUB | Subtract values of two registers |
+| 0100 | MUL | Multiply values of two registers |
+| 0101 | DIV | Divide values of two registers |
+| 0110 | LOAD | Load a value from memory to register |
+| 0111 | STORE | Store register value to memory |
+| 1000 | JMP | Unconditional jump to address |
+| 1001 | JEQ | Jump if equal |
+| 1010 | JNE | Jump if not equal |
+| 1011 | CALL | Call subroutine at address |
+| 1100 | RET | Return from subroutine |
+| 1101 | PUSH | Push register value to stack |
+| 1110 | POP | Pop top of stack into register |
 | 1111 | EXTENDED | Reserved for future instructions |
 
 Note: For instructions with two register operands, the first register is always the destination, and the second register is the source. For single-operand instructions, the register is the destination.

--- a/lib/svm/README.md
+++ b/lib/svm/README.md
@@ -36,21 +36,21 @@ Directives:
 .const defines named constants.
 Instruction Set
 Opcode	Instruction	Description
-0	MOV	Move value between registers or load an immediate value
-1	ADD	Add values of two registers
-2	SUB	Subtract values of two registers
-3	MUL	Multiply values of two registers
-4	DIV	Divide values of two registers
-5	LOAD	Load a value from memory to register
-6	STORE	Store register value to memory
-7	JMP	Unconditional jump to address
-8	JEQ	Jump if equal
-9	JNE	Jump if not equal
-10	CALL	Call subroutine at address
-11	RET	Return from subroutine
-12	PUSH	Push register value to stack
-13	POP	Pop top of stack into register
-14	INT	Trigger interrupt for I/O
+0	INT	Trigger interrupt for I/O
+1	MOV	Move value between registers or load an immediate value
+2	ADD	Add values of two registers
+3	SUB	Subtract values of two registers
+4	MUL	Multiply values of two registers
+5	DIV	Divide values of two registers
+6	LOAD	Load a value from memory to register
+7	STORE	Store register value to memory
+8	JMP	Unconditional jump to address
+9	JEQ	Jump if equal
+10	JNE	Jump if not equal
+11	CALL	Call subroutine at address
+12	RET	Return from subroutine
+13	PUSH	Push register value to stack
+14	POP	Pop top of stack into register
 15	EXTENDED	Reserved for future instructions
 Example Usage
 Writing and Running a Program with the Assembler and Virtual Machine

--- a/lib/svm/instruction_set.rb
+++ b/lib/svm/instruction_set.rb
@@ -7,7 +7,7 @@ module Svm
     REGISTER_MASK = 0xFFFF  # 16-bit mask for registers
 
     # Define opcodes in an array first
-    OPCODES = %w[MOV ADD SUB MUL DIV LOAD STORE JMP JEQ JNE CALL RET PUSH POP INT EXTENDED]
+    OPCODES = %w[INT MOV ADD SUB MUL DIV LOAD STORE JMP JEQ JNE CALL RET PUSH POP EXTENDED]
     
     # Create constants from the array
     OPCODES.each_with_index do |opcode, index|

--- a/lib/svm/virtual_machine.rb
+++ b/lib/svm/virtual_machine.rb
@@ -47,6 +47,8 @@ class Svm::VirtualMachine
     end
 
     case opcode
+    when INT
+      handle_interrupt(immediate_value)
     when MOV
       value = reg_y.zero? ? immediate_value : @registers[reg_y]
       @registers[reg_x] = value & REGISTER_MASK
@@ -86,8 +88,6 @@ class Svm::VirtualMachine
       push_word(@registers[reg_x])
     when POP
       @registers[reg_x] = pop_word
-    when INT
-      handle_interrupt(immediate_value)
     when EXTENDED
       return
     end

--- a/spec/svm/instruction_set_spec.rb
+++ b/spec/svm/instruction_set_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Svm::InstructionSet do
 
   describe 'opcodes' do
     it 'defines all expected opcodes as constants' do
-      expected_opcodes = %w[MOV ADD SUB MUL DIV LOAD STORE JMP JEQ JNE CALL RET PUSH POP INT EXTENDED]
+      expected_opcodes = %w[INT MOV ADD SUB MUL DIV LOAD STORE JMP JEQ JNE CALL RET PUSH POP EXTENDED]
       
       expected_opcodes.each_with_index do |opcode, index|
         expect(Svm::InstructionSet.const_get(opcode)).to eq(index)
@@ -21,9 +21,9 @@ RSpec.describe Svm::InstructionSet do
     end
 
     it 'assigns sequential values starting from 0' do
-      expect(Svm::InstructionSet::MOV).to eq(0)
-      expect(Svm::InstructionSet::ADD).to eq(1)
-      expect(Svm::InstructionSet::SUB).to eq(2)
+      expect(Svm::InstructionSet::INT).to eq(0)
+      expect(Svm::InstructionSet::MOV).to eq(1)
+      expect(Svm::InstructionSet::ADD).to eq(2)
       expect(Svm::InstructionSet::EXTENDED).to eq(15)
     end
   end

--- a/spec/svm/virtual_machine_spec.rb
+++ b/spec/svm/virtual_machine_spec.rb
@@ -40,11 +40,11 @@ RSpec.describe Svm::VirtualMachine do
   describe '#run' do
     it 'executes a simple program' do
       program = [
-        0x00, 0x00, 0x00, 0x0A,  # MOV R0, #10
-        0x04, 0x00, 0x00, 0x0E,  # MOV R1, #14
-        0x11, 0x00, 0x00, 0x00,  # ADD R0, R1
-        0x60, 0x00, 0x00, 0x80,  # STORE R0, 129
-        0xE0, 0x00, 0x00, 0x00   # INT #0 (halt)
+        vm.combine_opcode_byte(Svm::InstructionSet::MOV, 0, 0), 0x00, 0x00, 0x0A,  # MOV R0, #10
+        vm.combine_opcode_byte(Svm::InstructionSet::MOV, 1, 0), 0x00, 0x00, 0x0E,  # MOV R1, #14
+        vm.combine_opcode_byte(Svm::InstructionSet::ADD, 0, 1), 0x00, 0x00, 0x00,  # ADD R0, R1
+        vm.combine_opcode_byte(Svm::InstructionSet::STORE, 0, 0), 0x00, 0x00, 0x80,  # STORE R0, 128
+        vm.combine_opcode_byte(Svm::InstructionSet::INT, 0, 0), 0x00, 0x00, 0x00   # INT #0 (halt)
       ]
       vm.load_program(program)
       vm.run()
@@ -98,7 +98,7 @@ RSpec.describe Svm::VirtualMachine do
     end
 
     it 'executes MOV instruction' do
-      vm.load_program([vm.combine_opcode_byte(0,0,0), 0x00, 0x00, 0x0A])  # MOV R0, #10
+      vm.load_program([vm.combine_opcode_byte(Svm::InstructionSet::MOV,0,0), 0x00, 0x00, 0x0A])  # MOV R0, #10
       vm.send(:execute_instruction)
       expect(vm.instance_variable_get(:@registers)[0]).to eq(10)
     end
@@ -247,10 +247,10 @@ RSpec.describe Svm::VirtualMachine do
     it 'handles 16-bit values in registers' do
       vm = Svm::VirtualMachine.new
       program = [
-        0x00, 0x00, 0xFF, 0xFF,  # MOV R0, #65535 (max 16-bit value)
-        0x04, 0x00, 0x00, 0x01,  # MOV R1, #1
-        0x11, 0x00, 0x00, 0x00,  # ADD R0, R1 (0001 0001)
-        0xE0, 0x00, 0x00, 0x00   # INT #0 (halt)
+        vm.combine_opcode_byte(Svm::InstructionSet::MOV, 0, 0), 0x00, 0xFF, 0xFF,  # MOV R0, #65535
+        vm.combine_opcode_byte(Svm::InstructionSet::MOV, 1, 0), 0x00, 0x00, 0x01,  # MOV R1, #1
+        vm.combine_opcode_byte(Svm::InstructionSet::ADD, 0, 1), 0x00, 0x00, 0x00,  # ADD R0, R1
+        vm.combine_opcode_byte(Svm::InstructionSet::INT, 0, 0), 0x00, 0x00, 0x00   # INT #0 (halt)
       ]
       
       vm.load_program(program)
@@ -262,10 +262,10 @@ RSpec.describe Svm::VirtualMachine do
     it 'properly stores and loads 16-bit values' do
       vm = Svm::VirtualMachine.new
       program = [
-        0x00, 0x00, 0x12, 0x34,  # MOV R0, #0x1234
-        0x60, 0x00, 0x00, 0x80,  # STORE R0, 128
-        0x54, 0x00, 0x00, 0x80,  # LOAD R1, 128  (0101 0100 in binary)
-        0xE0, 0x00, 0x00, 0x00   # INT #0 (halt)
+        vm.combine_opcode_byte(Svm::InstructionSet::MOV, 0, 0), 0x00, 0x12, 0x34,  # MOV R0, #0x1234
+        vm.combine_opcode_byte(Svm::InstructionSet::STORE, 0, 0), 0x00, 0x00, 0x80,  # STORE R0, 128
+        vm.combine_opcode_byte(Svm::InstructionSet::LOAD, 1, 0), 0x00, 0x00, 0x80,  # LOAD R1, 128
+        vm.combine_opcode_byte(Svm::InstructionSet::INT, 0, 0), 0x00, 0x00, 0x00   # INT #0 (halt)
       ]
       
       vm.load_program(program)


### PR DESCRIPTION
# Improve VM safety by making INT the first opcode

This change improves VM safety by making `INT` the first opcode (`0x0`). When execution strays into uninitialized memory (which contains zeros), the VM will now interpret it as `INT #0` and halt, rather than as `MOV R0, #0` which could encourage code running in an unsafe way and possibly cause infinite loops.

## Key Changes
- Reordered `OPCODES` array in `InstructionSet` module
- Updated instruction tables in both README files 
- Updated all tests to use new opcode values
- Moved `INT` case to first position in `execute_instruction` switch
- Replaced hardcoded opcode values with `InstructionSet` constants