### PR TITLE
Implement relative jump addressing and enhance debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 
 # rspec failure tracking
 .rspec_status
+/log


### PR DESCRIPTION
# Implement relative jump addressing and enhance debugging

## Key Changes
- Replaced absolute addressing with relative jump addressing for JMP, JEQ, JNE, and CALL instructions
- Added relative jump calculation methods in VM
- Enhanced debug output with detailed register state tracking
- Added instruction execution limits to prevent infinite loops
- Added debug output redirection capabilities (file/stdout/custom handler)
- Fixed JNE instruction behavior
- Added helper methods for 16-bit signed conversions

## Technical Details
- Implemented `calculate_relative_jump` method for computing jump targets
- Added `unsigned_to_signed_16bit` helper for proper signed arithmetic
- Enhanced debug output format with PC, instruction, and register states
- Added configurable instruction limits with `set_instruction_limit`
- Improved test coverage for jump instructions and edge cases

## Other Improvements
- Added /log directory to .gitignore
- Improved example code in documentation
- Added comprehensive tests for relative jumps
- Enhanced error detection for infinite loops