### PR TITLE
Bg/document mov only for immediate values

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The Simple Virtual Machine (SVM) is a lightweight register-based virtual machine
   - [Virtual Machine](#virtual-machine)
   - [Assembler](#assembler)
 - [Instruction Set](#instruction-set)
+- [Interrupts](#interrupts)
 - [Example Usage](#example-usage)
 - [License](#license)
 
@@ -60,7 +61,7 @@ Each instruction is 32 bits (4 bytes) long, with the following format:
 | Opcode | Instruction | Description |
 |--------|-------------|-------------|
 | 0000 | INT | Trigger interrupt for I/O |
-| 0001 | MOV | Move value between registers or load an immediate value |
+| 0001 | MOV | Load an immediate value into register |
 | 0010 | ADD | Add values of two registers |
 | 0011 | SUB | Subtract values of two registers |
 | 0100 | MUL | Multiply values of two registers |
@@ -77,6 +78,34 @@ Each instruction is 32 bits (4 bytes) long, with the following format:
 | 1111 | EXTENDED | Reserved for future instructions |
 
 Note: For instructions with two register operands, the first register is always the destination, and the second register is the source. For single-operand instructions, the register is the destination.
+
+## Interrupts
+
+The SVM provides several interrupt operations for I/O and program control:
+
+| Interrupt | Operation | Description |
+|-----------|-----------|-------------|
+| INT #0    | Halt      | Stops program execution |
+| INT #1    | Print     | Prints value in R0 to stdout (prints "Output: <value>") |
+| INT #2    | Read TTY  | Reads a character from TTY into R0 |
+| INT #3    | Write TTY | Writes character in R0 to TTY |
+
+Example interrupt usage:
+
+```asm
+; Basic output example
+MOV R0, #65      ; Load ASCII 'A' into R0
+INT #3           ; Write 'A' to TTY
+INT #0           ; Halt program
+
+; TTY echo example
+START:
+  INT #2         ; Read character from TTY into R0
+  INT #3         ; Write character to TTY
+  JMP START      ; Loop forever
+```
+
+Note: TTY operations (INT #2 and INT #3) require starting the VM's TTY connection using `vm.start_tty` before execution.
 
 ## Example Usage
 

--- a/lib/svm/README.md
+++ b/lib/svm/README.md
@@ -8,6 +8,7 @@ Components
 Virtual Machine
 Assembler
 Instruction Set
+Interrupts
 Example Usage
 License
 Installation
@@ -37,7 +38,7 @@ Directives:
 Instruction Set
 Opcode	Instruction	Description
 0	INT	Trigger interrupt for I/O
-1	MOV	Move value between registers or load an immediate value
+1	MOV	Load an immediate value into register
 2	ADD	Add values of two registers
 3	SUB	Subtract values of two registers
 4	MUL	Multiply values of two registers
@@ -52,6 +53,16 @@ Opcode	Instruction	Description
 13	PUSH	Push register value to stack
 14	POP	Pop top of stack into register
 15	EXTENDED	Reserved for future instructions
+Interrupts
+The SVM supports several interrupts for I/O operations and program control:
+
+| Interrupt | Description |
+|-----------|-------------|
+| INT #0    | Halt - Stops program execution |
+| INT #1    | Output - Prints value in R0 to stdout |
+| INT #2    | Input - Reads a character from TTY into R0 |
+| INT #3    | Output - Writes character in R0 to TTY |
+
 Example Usage
 Writing and Running a Program with the Assembler and Virtual Machine
 ```ruby


### PR DESCRIPTION
# Update documentation to clarify MOV instruction and add Interrupts section

## Key Changes
- Updated MOV instruction description to only handle immediate values
- Added dedicated Interrupts section to both README files
- Documented all available interrupts (INT 0 through INT 3)
- Added example code for interrupt usage
- Added note about TTY connection requirement for TTY operations

## Technical Details
- Clarified MOV instruction limitations in instruction set documentation
- Added comprehensive interrupts section with detailed descriptions
- Added example code demonstrating interrupt usage
- Updated both main README and lib/svm/README
- Added TTY connection requirement note for relevant interrupts

## Impact
- Improves clarity of MOV instruction documentation
- Makes interrupt functionality more discoverable
- Provides clear examples of interrupt usage
- Helps prevent confusion about TTY-related operations
- Makes documentation more complete and accurate
